### PR TITLE
fixed issue #1476 scroll-behavior example problem

### DIFF
--- a/files/en-us/web/css/scroll-behavior/index.html
+++ b/files/en-us/web/css/scroll-behavior/index.html
@@ -103,7 +103,7 @@ scroll-page {
 
 <h4 id="Result">Result</h4>
 
-<p>{{ EmbedLiveSample("Setting_smooth_scroll_behavior", "100%", 250) }}</p>
+<p>{{ EmbedLiveSample("Setting_smooth_scroll_behavior", "100%", "450px") }}</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
**Height of iframe was inappropriate** 
Height of iframe was **250px** which was  too less so I updated height to **450px.**